### PR TITLE
Normalize filesystemencoding codec name

### DIFF
--- a/src/backports/os.py
+++ b/src/backports/os.py
@@ -93,15 +93,16 @@ def _chunks(b, indexes):
 
 
 def _fscodec():
+    import codecs  # Use codecs.lookup() for name normalisation.
     encoding = sys.getfilesystemencoding()
+    encoding = codecs.lookup(encoding).name
     if encoding == 'mbcs':
         errors = 'strict'
     else:
         errors = 'surrogateescape'
 
     # XXX backport: Do we need to hack around Python 2's UTF-8 codec?
-    import codecs  # Use codecs.lookup() for name normalisation.
-    _HACK_AROUND_PY2_UTF8 = (sys.version_info < (3,) and
+        _HACK_AROUND_PY2_UTF8 = (sys.version_info < (3,) and
                              codecs.lookup(encoding) == codecs.lookup('utf-8'))
 
     # XXX backport: chr(octet) became bytes([octet])


### PR DESCRIPTION
This allows to avoid weird cases where the codec may not be properly
recognized. 
Link: https://github.com/nexB/scancode-toolkit/issues/688

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>