### PR TITLE
Hack around Python 2 ASCII encoding bug / incompatibility

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,9 @@
 [run]
 branch = True
 
+# We seem to need timid mode to get correct results.
+timid = True
+
 source =
     src
     tests

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -20,4 +20,16 @@ class FSEncodingTests(unittest.TestCase):
                 bytesfn = os.fsencode(fn)
             except UnicodeEncodeError:
                 continue
+
+            # XXX backport: Ignore bug in future.utils.surrogateescape.replace_surrogate_encode()
+            # by treating the below NameError like the above UnicodeEncodeError.
+            #
+            # Bug: https://github.com/PythonCharmers/python-future/issues/256
+            # (This workaround can be removed once that is fixed.)
+            except NameError as e:
+                if e.message == "global name 'exc' is not defined":
+                    continue
+                else:
+                    raise
+
             self.assertEqual(os.fsdecode(bytesfn), fn)

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -26,7 +26,7 @@ class FSEncodingTests(unittest.TestCase):
             #
             # Bug: https://github.com/PythonCharmers/python-future/issues/256
             # (This workaround can be removed once that is fixed.)
-            except NameError as e:
+            except NameError as e:  # pragma: no cover
                 if e.message == "global name 'exc' is not defined":
                     continue
                 else:

--- a/tox.ini
+++ b/tox.ini
@@ -39,5 +39,5 @@ commands =
     env LANG= python -m unittest discover tests
 
     codecov: coverage run -m unittest discover tests
-    codecov: env LANG= coverage run -m unittest discover tests
+    codecov: env LANG= coverage run --append -m unittest discover tests
     codecov: codecov -e TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,11 @@ deps =
 usedevelop =
     codecov: true
 
+whitelist_externals =
+    env
+
+# Note: This runs the test suite with both the current locale's encoding,
+# and with LANG empty, to test against ASCII.
 commands =
     # XXX: This will currently run the tests twice under codecov, but oh well.
     # TODO: Use a factor-based override or negation for this sometime?
@@ -31,6 +36,8 @@ commands =
     # https://github.com/tox-dev/tox/issues/189
     # https://github.com/tox-dev/tox/issues/292
     python -m unittest discover tests
+    env LANG= python -m unittest discover tests
 
     codecov: coverage run -m unittest discover tests
+    codecov: env LANG= coverage run -m unittest discover tests
     codecov: codecov -e TOXENV


### PR DESCRIPTION
For context, see previous PRs #4 and #7.

This expands the test coverage to run against ASCII, adds a workaround for https://github.com/PythonCharmers/python-future/issues/256 (which testing against ASCII runs into), and enables the hack for Python 2 ASCII (see comments).